### PR TITLE
feat: 회원가입 API 연동 및 성공 시 토스트 알림 기능 추가

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -49,7 +49,7 @@ function LoginPage() {
       console.log('로그인 성공:', response.data);
       localStorage.setItem('accessToken', response.data.data.accessToken);
       router.push('/');
-    } catch (error: any) {
+    } catch (error) {
       console.error('로그인 실패:', error);
       alert('로그인 실패했습니다.');
     }


### PR DESCRIPTION
## **변경 사항 요약**
회원가입 프로세스를 백엔드 API와 연동하고, 회원가입 성공 시 사용자에게 즉각적인 피드백을 제공하는 토스트 알림 기능을 구현했습니다.

## **주요 기능**
### **회원가입 API 연동**
```
// 회원가입 처리 함수
try {
  const response = await httpClient.post('/auth/signup', {
    username: formData.name,
    email: formData.email,
    password: formData.password,
    confirm_password: formData.confirmPassword
  });

  showToast('회원가입에 성공했습니다.');
  router.push('/login');
} catch (error) {
  console.error('회원가입 실패: ', error);
  showToast('회원가입에 실패했습니다.');
}
```

### **토스트 알림 구현**
- **성공 메시지**: "회원가입에 성공했습니다."
- **표시 시간**: 3초 후 자동 사라짐
- **후속 액션**: 토스트 표시 후 로그인 페이지로 자동 리다이렉트

## **테스트 방법**
### **정상 플로우 테스트**
1. 회원가입 페이지에서 유효한 정보 입력
2. "회원가입" 버튼 클릭
4. 성공 토스트 메시지 확인
5. 로그인 페이지로 자동 이동 확인

### **체크리스트**
- [x] 회원가입 API 연동 완료
- [x] 성공 토스트 알림 구현 완료

### **추가 고려사항**
- 이메일 인증 기능 추가 계획
- 소셜 로그인 연동 준비