### PR TITLE
fix: any 제거 및 useMemo/useEffect 의존성 정리, 불필요 변수 제거

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -57,13 +57,24 @@ function LoginPage() {
       } else {
         showToast("로그인 처리 중 오류가 발생했습니다.");
       }
-    } catch (error: any) {
-      // 서버에서 422 등으로 에러 응답 시
-      if (error?.response?.data?.errors?.email) {
-        showToast(error.response.data.errors.email);
-      } else {
-        showToast("로그인 실패했습니다.");
+    } catch (error: unknown) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "response" in error &&
+        typeof (error as { response?: unknown }).response === "object"
+      ) {
+        const err = error as {
+          response?: {
+            data?: { errors?: { email?: string } };
+          };
+        };
+        if (err.response?.data?.errors?.email) {
+          showToast(err.response.data.errors.email);
+          return;
+        }
       }
+      showToast("로그인 실패했습니다.");
     }
   };
 

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -61,7 +61,7 @@ function SignupPage() {
     e.preventDefault();
     if (!validateForm()) return;
     try {
-      const response = await httpClient.post("/auth/signup", {
+      await httpClient.post("/auth/signup", {
         username: formData.name,
         email: formData.email,
         password: formData.password,

--- a/frontend/src/features/retrospect/components/Calendar.tsx
+++ b/frontend/src/features/retrospect/components/Calendar.tsx
@@ -1,16 +1,16 @@
-'use client';
+"use client";
 
-import { useCallback, useMemo, useEffect, useRef } from 'react';
-import FullCalendar from '@fullcalendar/react';
-import dayGridPlugin from '@fullcalendar/daygrid';
-import interactionPlugin, { DateClickArg } from '@fullcalendar/interaction';
-import { DayCellContentArg } from '@fullcalendar/core';
-import './Calendar.css';
-import { getDailyEmotionMemos } from '../../../lib/api/retrospect';
-import { formatDateToString } from '../../../utils/retrospectUtils';
-import { useDateStore } from '@/store/useDateStore';
-import { useRetrospectStore } from '@/store/useRestrospectStore';
-import Image from 'next/image';
+import { useCallback, useMemo, useEffect, useRef } from "react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
+import { DayCellContentArg } from "@fullcalendar/core";
+import "./Calendar.css";
+import { getDailyEmotionMemos } from "../../../lib/api/retrospect";
+import { formatDateToString } from "../../../utils/retrospectUtils";
+import { useDateStore } from "@/store/useDateStore";
+import { useRetrospectStore } from "@/store/useRestrospectStore";
+import Image from "next/image";
 
 interface CalendarProps {
   onDateModalOpen: () => void;
@@ -18,7 +18,8 @@ interface CalendarProps {
 
 const Calendar = ({ onDateModalOpen }: CalendarProps) => {
   const { selectedDate, setSelectedDate } = useDateStore();
-  const { emotionMemoList, setEmotionMemoList, selectedYearMonth } = useRetrospectStore();
+  const { emotionMemoList, setEmotionMemoList, selectedYearMonth } =
+    useRetrospectStore();
   const calendarRef = useRef<FullCalendar>(null);
 
   const onDateClick = (dateInfo: DateClickArg) => {
@@ -36,23 +37,28 @@ const Calendar = ({ onDateModalOpen }: CalendarProps) => {
     }, {} as Record<string, string>);
   }, [emotionMemoList]);
 
-  const onDayCellClassNames = useCallback((dayCell: DayCellContentArg) => {
-    const classes = [];
+  const onDayCellClassNames = useCallback(
+    (dayCell: DayCellContentArg) => {
+      const classes = [];
 
-    if (formatDateToString(dayCell.date) === formatDateToString(selectedDate)) {
-      classes.push('selected');
-    }
+      if (
+        formatDateToString(dayCell.date) === formatDateToString(selectedDate)
+      ) {
+        classes.push("selected");
+      }
 
-    const emotionType = emotionByDateMap[formatDateToString(dayCell.date)];
-    if (emotionType) {
-      classes.push(`emotion-${emotionType}`);
-    }
+      const emotionType = emotionByDateMap[formatDateToString(dayCell.date)];
+      if (emotionType) {
+        classes.push(`emotion-${emotionType}`);
+      }
 
-    return classes;
-  }, [selectedDate, emotionByDateMap]);
+      return classes;
+    },
+    [selectedDate, emotionByDateMap]
+  );
 
   const onDayCellContent = (e: DayCellContentArg) => {
-    return e.dayNumberText.replace('일', '');
+    return e.dayNumberText.replace("일", "");
   };
 
   useEffect(() => {
@@ -65,7 +71,11 @@ const Calendar = ({ onDateModalOpen }: CalendarProps) => {
     getEmotionMemos();
 
     if (calendarRef.current) {
-      const targetDate = new Date(selectedYearMonth.year, selectedYearMonth.month - 1, 1);
+      const targetDate = new Date(
+        selectedYearMonth.year,
+        selectedYearMonth.month - 1,
+        1
+      );
       const calendarApi = calendarRef.current.getApi();
       calendarApi.gotoDate(targetDate);
     }
@@ -75,10 +85,16 @@ const Calendar = ({ onDateModalOpen }: CalendarProps) => {
     <section aria-label="회고 캘린더">
       <button
         onClick={onDateNavigation}
-        className='flex gap-2 items-center text-xl font-bold mb-8'
+        className="flex gap-2 items-center text-xl font-bold mb-8"
       >
         {selectedYearMonth.year}. {selectedYearMonth.month}
-        <Image src="/dropdown.svg" alt="달력 선택" width={20} height={20} style={{ width: 20, height: 20 }} />
+        <Image
+          src="/dropdown.svg"
+          alt="달력 선택"
+          width={20}
+          height={20}
+          style={{ width: 20, height: 20 }}
+        />
       </button>
       <div className="calendar-container">
         <FullCalendar


### PR DESCRIPTION
- login 페이지에서 any 사용 제거, 타입 안전하게 error 처리
- signup 페이지에서 사용하지 않는 response 변수 제거
- Calendar 컴포넌트에서 useMemo/useEffect의 setEmotionMemoList 의존성 정리
- ESLint 및 타입 경고/에러 해결