### PR TITLE
fix: 프로필 통계값 undefined 시 0으로 안전하게 변환

### DIFF
--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -75,13 +75,13 @@ export default function ProfilePage() {
       setUserStats(response.stickers);
 
       const total =
-        response.todos.pending +
-        response.todos.success +
-        response.todos.archive;
+        Number(response.todos?.pending ?? 0) +
+        Number(response.todos?.success ?? 0) +
+        Number(response.todos?.archive ?? 0);
       setTotal(total);
-      setPending(response.todos.pending);
-      setSuccess(response.todos.success);
-      setArchive(response.todos.archive);
+      setPending(Number(response.todos?.pending ?? 0));
+      setSuccess(Number(response.todos?.success ?? 0));
+      setArchive(Number(response.todos?.archive ?? 0));
     };
     userProfile();
   }, []);


### PR DESCRIPTION
- todos 통계값(Number) 변환 시 undefined일 경우 0으로 처리
- setTotal, setPending, setSuccess, setArchive 모두 안전하게 변환
- API 응답값이 없을 때도 프로필 페이지가 정상 동작하도록 개선