### PR TITLE
refactor: 백엔드 라우터 분리 및 프론트엔드 타입 안전성 개선

### DIFF
--- a/backend/controller/todo.controller.ts
+++ b/backend/controller/todo.controller.ts
@@ -69,6 +69,15 @@ export const getAllTodosController = async (req: Request, res: Response) => {
   }
 };
 
+// 투두 조회 (date 쿼리 파라미터에 따라 분기)
+export const getTodosController = async (req: Request, res: Response) => {
+  const { date } = req.query;
+  if (date) {
+    return getTodosByDateController(req, res);
+  }
+  return getAllTodosController(req, res);
+};
+
 //투두 날짜별 조회
 export const getTodosByDateController = async (req: Request, res: Response) => {
   try {

--- a/backend/router/todo.router.ts
+++ b/backend/router/todo.router.ts
@@ -5,6 +5,7 @@ import {
   deleteTodoController,
   getAllTodosController,
   getTodosByDateController,
+  getTodosController,
   upDateTodoController,
   updateTodoStatusController,
   moveToArchiveController,
@@ -20,17 +21,8 @@ const router = express.Router();
 
 // 투두 등록
 router.post('/', authenticate, createTodoController);
-// 투두 전체 조회 (date 쿼리 파라미터가 없을 때)
-router.get('/', authenticate, (req: Request, res: Response) => {
-  const { date } = req.query;
-  if (date) {
-    // date 쿼리 파라미터가 있으면 날짜별 조회
-    return getTodosByDateController(req, res);
-  } else {
-    // date 쿼리 파라미터가 없으면 전체 조회
-    return getAllTodosController(req, res);
-  }
-});
+// 투두 조회 (date 쿼리 파라미터에 따라 분기)
+router.get('/', authenticate, getTodosController);
 // 투두 날짜별 조회 (기존 호환성을 위해 유지)
 router.get('/by-date', authenticate, getTodosByDateController);
 

--- a/frontend/src/components/pages/MyDayPage.tsx
+++ b/frontend/src/components/pages/MyDayPage.tsx
@@ -123,6 +123,25 @@ export default function MyDayPage() {
     isLoading: guestLoading,
   } = useGuestTasks(selectedDate);
 
+  // 게스트 모드에서 할 일 저장/수정 성공 시 호출할 콜백
+  const handleGuestTaskSuccess = useCallback(() => {
+    // 게스트 모드일 때만 상태 업데이트
+    if (isGuest) {
+      // 로컬 스토리지에서 최신 데이터를 다시 불러와서 상태 업데이트
+      const dateStr = selectedDate.toISOString().split("T")[0];
+      const stored = localStorage.getItem(`guest-tasks-${dateStr}`);
+      if (stored) {
+        try {
+          const updatedTasks = JSON.parse(stored);
+          setGuestTasks(updatedTasks);
+        } catch {
+          // JSON 파싱 실패 시 빈 배열로 설정
+          setGuestTasks([]);
+        }
+      }
+    }
+  }, [isGuest, selectedDate, setGuestTasks]);
+
   // 인증된 사용자일 때 서버 API 사용
   const {
     data: tasks,
@@ -426,6 +445,7 @@ export default function MyDayPage() {
           task={editTask || undefined}
           defaultPriority={defaultPriority}
           isGuest={isGuest}
+          onSuccess={handleGuestTaskSuccess}
         />
       </FullScreenModal>
 

--- a/frontend/src/features/myday/components/TaskFormModal.tsx
+++ b/frontend/src/features/myday/components/TaskFormModal.tsx
@@ -34,6 +34,7 @@ interface TaskFormModalProps {
   task?: CommonTask;
   defaultPriority?: "must" | "should" | "remind";
   isGuest?: boolean;
+  onSuccess?: () => void; // 게스트 모드에서 성공 시 호출할 콜백
 }
 
 const inputSize: Size = "md";
@@ -62,6 +63,7 @@ export default function TaskFormModal({
   task,
   defaultPriority = "must",
   isGuest = false,
+  onSuccess,
 }: TaskFormModalProps) {
   const [label, setLabel] = useState(task ? task.title : "");
   const [priority, setPriority] = useState<"must" | "should" | "remind">(
@@ -104,7 +106,7 @@ export default function TaskFormModal({
     let updatedTasks;
     if (task) {
       // 수정 모드
-      updatedTasks = existingTasks.map((t: Record<string, unknown>) =>
+      updatedTasks = existingTasks.map((t: CommonTask) =>
         t.id === task.id ? { ...t, ...newTask } : t
       );
     } else {
@@ -144,7 +146,10 @@ export default function TaskFormModal({
               ? "할 일이 수정되었습니다! ✏️"
               : "새로운 할 일이 등록되었습니다! ✅"
           );
-          window.location.reload(); // 페이지 새로고침으로 상태 업데이트
+          // 성공 콜백 호출로 상태 업데이트 (페이지 새로고침 대신)
+          if (onSuccess) {
+            onSuccess();
+          }
         } else {
           showToast("할 일 저장에 실패했습니다 😭");
         }


### PR DESCRIPTION
- 백엔드: 라우터 인라인 로직을 getTodosController로 분리
- 프론트엔드: Record<string,unknown> → CommonTask 타입으로 변경
- 성능: 게스트 모드에서 window.location.reload() 제거, 콜백 기반 상태 업데이트"