### PR TITLE
feat: 날짜 키 처리 방식 통일로 캐시 동기화 문제 해결

### DIFF
--- a/backend/service/todo.service.ts
+++ b/backend/service/todo.service.ts
@@ -10,6 +10,8 @@ interface ITodo {
 
 // 투두 저장
 export const createTodoService = async (input: ITodo) => {
+  console.log('🔍 createTodoService 입력:', input);
+
   return await prisma.todos.create({
     data: {
       title: input.title,
@@ -29,15 +31,17 @@ export const getAllTodosService = async (userId: number) => {
   });
 };
 
-//투두 특정 날짜 조회
+// 투두 특정 날짜 조회
 export const getTodosByDateService = async (userId: number, date: string) => {
+  console.log('🔍 getTodosByDateService 호출:', { userId, date });
+
   return await prisma.todos.findMany({
     where: { userId, date, status: { in: ['pending', 'retry', 'success'] } },
     orderBy: { createdAt: 'asc' },
   });
 };
 
-//투두 업데이트 (공통 함수)
+// 투두 업데이트 (공통 함수)
 export const updateTodoService = async (
   todoId: number,
   userId: number,
@@ -49,11 +53,17 @@ export const updateTodoService = async (
   },
   statusFilter?: string
 ) => {
+  console.log('🔍 updateTodoService 호출:', {
+    todoId,
+    userId,
+    data,
+    statusFilter,
+  });
+
   const where: any = { id: todoId, userId };
   if (statusFilter) {
     where.status = statusFilter;
   }
-
   return await prisma.todos.updateMany({
     where,
     data: {
@@ -73,7 +83,6 @@ export const deleteTodoService = async (
   if (statusFilter) {
     where.status = statusFilter;
   }
-
   return await prisma.todos.deleteMany({ where });
 };
 
@@ -107,18 +116,25 @@ export const moveToRetryService = async (todoId: number, userId: number) => {
     return { count: 0 };
   }
 
-  // 할 일의 현재 날짜 기준으로 다음날 계산
-  const currentDate = new Date(todo.date);
+  // YYYY-MM-DD 문자열을 파싱할 때 UTC 기준으로 처리
+  const currentDate = new Date(todo.date + 'T00:00:00.000Z');
   const nextDate = new Date(currentDate);
-  nextDate.setDate(currentDate.getDate() + 1);
+  nextDate.setUTCDate(currentDate.getUTCDate() + 1);
   const nextDateString = nextDate.toISOString().split('T')[0];
+
+  console.log('🔍 moveToRetryService 날짜 계산:', {
+    originalDate: todo.date,
+    currentDate: currentDate.toISOString(),
+    nextDate: nextDate.toISOString(),
+    nextDateString,
+  });
 
   return await prisma.todos.updateMany({
     where: { id: todoId, userId },
     data: {
       status: 'retry',
       retryCount: todo.retryCount + 1,
-      date: nextDateString, // 할 일의 현재 날짜 기준 다음날로 이동
+      date: nextDateString,
     },
   });
 };

--- a/frontend/src/features/archive/ArchivePage.tsx
+++ b/frontend/src/features/archive/ArchivePage.tsx
@@ -88,19 +88,32 @@ export default function ArchivePage() {
       showToast("보류함 할 일 삭제에 실패했습니다 😞");
     }
   };
-
   const handleMoveToToday = async (id: string) => {
     try {
       await moveToTodayFromArchive(Number(id));
-      const todayKey = selectedDate.toISOString().split("T")[0];
-      // 1. 보류함 캐시에서 즉시 제거 (optimistic)
+
+      // 🔥 수정: 일관된 날짜 키 사용
+      const todayKey = selectedDate.toLocaleDateString("en-CA");
+
+      // 1. 보관함 캐시에서 즉시 제거 (optimistic)
       queryClient.setQueryData(["archiveTasks"], (old: ArchiveTask[] = []) =>
         old.filter((task) => String(task.id) !== id)
       );
-      // 2. MyDay만 invalidate (archive는 setQueryData로 이미 반영됨)
+
+      // 2. 오늘 할 일 캐시 무효화 및 리페치 (바로 반영되도록)
       await queryClient.invalidateQueries({ queryKey: ["tasks", todayKey] });
+      await queryClient.refetchQueries({ queryKey: ["tasks", todayKey] });
+
+      // 3. 보관함 캐시도 서버와 동기화
+      await queryClient.invalidateQueries({ queryKey: ["archiveTasks"] });
+
       showToast("오늘 할 일로 이동했습니다 📅");
-    } catch {
+    } catch (error) {
+      console.error("오늘 할 일로 이동 실패:", error);
+
+      // 실패 시 캐시 롤백
+      queryClient.invalidateQueries({ queryKey: ["archiveTasks"] });
+
       showToast("오늘 할 일로 이동에 실패했습니다 😞");
     }
   };

--- a/frontend/src/features/myday/MyDayPage.tsx
+++ b/frontend/src/features/myday/MyDayPage.tsx
@@ -17,6 +17,7 @@ import dynamic from "next/dynamic";
 import { DropResult } from "@hello-pangea/dnd";
 import useAuthStore from "@/store/useAuthStore";
 import { CommonTask } from "@/types";
+
 // ⚡ 성능 최적화: Dynamic imports 개선
 const DragDropWrapper = dynamic(
   () => import("@/components/ui/DragDrop/DragDropWrapper"),
@@ -118,39 +119,12 @@ export default function MyDayPage() {
     isError,
     error,
   } = useQuery({
-    queryKey: ["tasks", selectedDate.toISOString().split("T")[0]],
+    // 🔥 수정: 쿼리 키를 일관된 방식으로
+    queryKey: ["tasks", selectedDate.toLocaleDateString("en-CA")],
     queryFn: () => getTasksByDate(selectedDate),
     enabled: isInitialized && !isGuest && typeof window !== "undefined",
     staleTime: 1000 * 60 * 5, // 5분간 fresh 상태 유지
   });
-
-  // 🚀 성능 최적화: 프리페칭 변수 제거 (사용하지 않음)
-  // const nextDate = useMemo(() => {
-  //   const next = new Date(selectedDate);
-  //   next.setDate(next.getDate() + 1);
-  //   return next;
-  // }, [selectedDate]);
-
-  // const prevDate = useMemo(() => {
-  //   const prev = new Date(selectedDate);
-  //   prev.setDate(prev.getDate() - 1);
-  //   return prev;
-  // }, [selectedDate]);
-
-  // 🚀 성능 최적화: 프리페칭 비활성화 (필요시에만 로드)
-  // useQuery({
-  //   queryKey: ["tasks", nextDate.toISOString().split("T")[0]],
-  //   queryFn: () => getTasksByDate(nextDate),
-  //   enabled: isInitialized && !isGuest && typeof window !== "undefined",
-  //   staleTime: 1000 * 60 * 10,
-  // });
-
-  // useQuery({
-  //   queryKey: ["tasks", prevDate.toISOString().split("T")[0]],
-  //   queryFn: () => getTasksByDate(prevDate),
-  //   enabled: isInitialized && !isGuest && typeof window !== "undefined",
-  //   staleTime: 1000 * 60 * 10,
-  // });
 
   // 게스트 모드용 상태
   const { guestTasks, refreshGuestTasks } = useGuestTasks(selectedDate);
@@ -270,8 +244,8 @@ export default function MyDayPage() {
           await updateTask(updated.id, {
             priority: newPriority as "must" | "should" | "remind",
           });
-          // 특정 날짜의 캐시만 무효화
-          const dateKey = selectedDate.toISOString().split("T")[0];
+          // 🔥 수정: 캐시 키를 일관된 방식으로
+          const dateKey = selectedDate.toLocaleDateString("en-CA");
           queryClient.invalidateQueries({ queryKey: ["tasks", dateKey] });
         }
       }

--- a/frontend/src/features/myday/components/DateHeader.tsx
+++ b/frontend/src/features/myday/components/DateHeader.tsx
@@ -7,6 +7,7 @@ import { useDateStore } from "@/store/useDateStore";
 import { motion, useMotionValue, useAnimation } from "framer-motion";
 import { useEffect, useMemo, useCallback } from "react";
 import React from "react";
+import { getTodayInKorea } from "@/utils/dateUtils";
 
 const DateHeader = React.memo(() => {
   const { selectedDate, setSelectedDate } = useDateStore();
@@ -15,24 +16,20 @@ const DateHeader = React.memo(() => {
   const gap = 50;
   const centerIndex = 3;
 
-  // 7개 날짜 배열 생성을 메모이제이션
+  // 🔥 수정: selectedDate를 기준으로 7개 날짜 배열 생성
   const dates = useMemo(() => {
     const arr = [];
-    // 항상 오늘 날짜를 기준으로 생성
-    const today = new Date();
-    const koreaTime = new Date(
-      today.toLocaleString("en-US", { timeZone: "Asia/Seoul" })
-    );
-    // 시간을 00:00:00으로 설정하여 날짜만 비교하도록 함
-    koreaTime.setHours(0, 0, 0, 0);
+    const baseDate = new Date(selectedDate);
+    baseDate.setHours(0, 0, 0, 0); // 시간을 0으로 설정
 
     for (let i = -3; i <= 3; i++) {
-      const d = new Date(koreaTime);
-      d.setDate(koreaTime.getDate() + i);
+      const d = new Date(baseDate);
+      d.setDate(baseDate.getDate() + i);
+      d.setHours(0, 0, 0, 0); // 시간을 0으로 설정하여 날짜만 처리
       arr.push(d);
     }
     return arr;
-  }, []); // selectedDate 의존성 제거
+  }, [selectedDate]); // 🔥 의존성에 selectedDate 추가
 
   const x = useMotionValue(0);
   const controls = useAnimation();
@@ -51,10 +48,12 @@ const DateHeader = React.memo(() => {
   );
 
   useEffect(() => {
-    // requestAnimationFrame을 사용하여 레이아웃 계산을 다음 프레임으로 지연
+    // 🔥 수정: 선택된 날짜는 항상 중앙(index 3)에 위치
+    const targetX = 0; // 중앙 위치
+
     const rafId = requestAnimationFrame(() => {
-      controls.start({ x: 0 });
-      x.set(0);
+      controls.start({ x: targetX });
+      x.set(targetX);
     });
 
     return () => cancelAnimationFrame(rafId);
@@ -78,18 +77,15 @@ const DateHeader = React.memo(() => {
         onDragEnd={handleDragEnd}
       >
         {dates.map((date, idx) => {
+          // 🔥 수정: 중앙 인덱스(3)가 항상 선택된 날짜
           const isCenter = idx === centerIndex;
-          // 한국 시간 기준으로 오늘 날짜와 비교
-          const today = new Date();
-          const koreaToday = new Date(
-            today.toLocaleString("en-US", { timeZone: "Asia/Seoul" })
-          );
-          koreaToday.setHours(0, 0, 0, 0);
-          const isToday = isSameDay(date, koreaToday);
+          // 오늘 날짜와 비교
+          const today = getTodayInKorea();
+          const isToday = isSameDay(date, today);
 
           return (
             <div
-              key={idx}
+              key={`${date.getTime()}-${idx}`} // 🔥 수정: 고유한 키 생성
               className={clsx(
                 "flex flex-row items-center transition-all cursor-pointer",
                 {

--- a/frontend/src/features/myday/components/TaskFormModal.tsx
+++ b/frontend/src/features/myday/components/TaskFormModal.tsx
@@ -10,7 +10,7 @@ import RadioButton from "@/components/ui/Radio/RadioButton";
 import { createTask, updateTask } from "@/lib/api/tasks";
 import { createGuestTask, updateGuestTask } from "@/lib/api/guestTasks";
 import { useQueryClient } from "@tanstack/react-query";
-import { format, parseISO } from "date-fns";
+import { parseISO } from "date-fns";
 import { useToast } from "@/components/ui/Toast/ToastProvider";
 import Image from "next/image";
 
@@ -132,7 +132,8 @@ export default function TaskFormModal({
       const taskData = {
         title: label.trim(),
         priority,
-        date: format(date, "yyyy-MM-dd"),
+        // 🔥 수정: format() 대신 toLocaleDateString() 사용
+        date: date.toLocaleDateString("en-CA"), // YYYY-MM-DD 형식으로 로컬 시간대 기준
       };
 
       if (isGuest) {
@@ -165,9 +166,10 @@ export default function TaskFormModal({
         showToast("새로운 할 일이 등록되었습니다! ✅");
       }
 
-      // React Query 캐시 무효화 (특정 날짜의 tasks 쿼리만 새로고침)
-      const dateKey = format(date, "yyyy-MM-dd");
-      queryClient.invalidateQueries({ queryKey: ["tasks", dateKey] });
+      // 🔥 수정: 캐시 키도 동일한 방식으로
+      const dateKey = date.toLocaleDateString("en-CA");
+      await queryClient.invalidateQueries({ queryKey: ["tasks", dateKey] });
+      await queryClient.refetchQueries({ queryKey: ["tasks", dateKey] });
 
       onClose();
     } catch {

--- a/frontend/src/features/retrospect/components/DateNavigationModal.tsx
+++ b/frontend/src/features/retrospect/components/DateNavigationModal.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useRetrospectStore } from "@/store/useRestrospectStore";
 import { useState } from "react";
 import Image from "next/image";
@@ -27,7 +26,7 @@ export default function DateNavigationModal({
   };
 
   return (
-    <div>
+    <div className="pb-safe">
       <div className="flex items-center justify-between pb-4 border-b border-gray-100">
         <h2 className="text-lg font-semibold">월 선택</h2>
         <button
@@ -57,9 +56,7 @@ export default function DateNavigationModal({
             style={{ width: "24px", height: "24px" }}
           />
         </button>
-
         <div className="text-xl font-bold">{selectedYear}년</div>
-
         <button
           onClick={onNextYear}
           className="w-10 h-10 flex items-center justify-center rounded-full hover:bg-gray-100"

--- a/frontend/src/lib/api/tasks.ts
+++ b/frontend/src/lib/api/tasks.ts
@@ -27,7 +27,7 @@ export const getAllTasks = async (): Promise<Task[]> => {
 export const getTasksByDate = async (date: Date | string): Promise<Task[]> => {
   try {
     const dateStr =
-      typeof date === "string" ? date : date.toISOString().split("T")[0];
+      typeof date === "string" ? date : date.toLocaleDateString("en-CA");
     const response = await httpClient.get(`/todos?date=${dateStr}`);
     return response.data.data;
   } catch (error: unknown) {

--- a/frontend/src/store/useDateStore.ts
+++ b/frontend/src/store/useDateStore.ts
@@ -1,21 +1,21 @@
 import { create } from "zustand";
-
-// 한국 시간대 기준으로 오늘 날짜를 가져오는 함수
-const getTodayInKorea = (): Date => {
-  const now = new Date();
-  const koreaTime = new Date(
-    now.toLocaleString("en-US", { timeZone: "Asia/Seoul" })
-  );
-  // 시간을 00:00:00으로 설정하여 날짜만 비교하도록 함
-  koreaTime.setHours(0, 0, 0, 0);
-  return koreaTime;
-};
+import { getTodayInKorea } from "@/utils/dateUtils";
 
 type DateState = {
   selectedDate: Date;
   setSelectedDate: (date: Date) => void;
 };
+
 export const useDateStore = create<DateState>((set) => ({
   selectedDate: getTodayInKorea(),
-  setSelectedDate: (date) => set({ selectedDate: date }),
+  setSelectedDate: (date) => {
+    const normalizedDate = new Date(date);
+    normalizedDate.setHours(0, 0, 0, 0);
+    set({ selectedDate: normalizedDate });
+  },
 }));
+
+// 스토어 리셋 함수 추가
+export const resetDateStore = () => {
+  useDateStore.setState({ selectedDate: getTodayInKorea() });
+};

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -1,0 +1,11 @@
+/**
+ * 한국 시간대 기준으로 오늘 날짜를 가져오는 함수
+ */
+export const getTodayInKorea = (): Date => {
+  const now = new Date();
+  const koreaTime = new Date(
+    now.toLocaleString("en-US", { timeZone: "Asia/Seoul" })
+  );
+  koreaTime.setHours(0, 0, 0, 0);
+  return koreaTime;
+};


### PR DESCRIPTION
- TaskItem 삭제/재시도/보류 기능에서 캐시 무효화 강화
- ArchivePage에서 오늘로 이동 시 즉시 반영되도록 수정
- TaskFormModal에서 등록/수정 후 바로 UI 업데이트
- 모든 날짜 키를 toLocaleDateString("en-CA")로 통일
- 새로고침 없이 실시간으로 변경사항 반영